### PR TITLE
Add debian/watch

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,3 @@
+version=3
+opts=uversionmangle=s/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha|b|a)\d*)$/$1~$2/,dversionmangle=s/\+(debian|dfsg|ds|deb)\d*$// \
+https://github.com/x42/silan/tags .*/v(\d.*)\.(?:tgz|tbz2|txz|tar\.(?:gz|bz2|xz))


### PR DESCRIPTION
Fixes: #3 and #6 

This will fix the uscan error from [DPT](https://tracker.debian.org/pkg/silan). 

Please consider taking over maintainer ship of the package as per https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=815492